### PR TITLE
refactor(pricing): reorganize pricing section layout

### DIFF
--- a/src/components/LandingContent.tsx
+++ b/src/components/LandingContent.tsx
@@ -6,6 +6,7 @@ import { Check, Sparkles, Clock, Trophy } from "lucide-react";
 import Image from "next/image";
 import { useLanguage } from "@/contexts/LanguageContext";
 import SubscribeButton from "@/components/SubscribeButton";
+import PricingSection from "@/components/PricingSection";
 
 export default function LandingContent() {
   const { t, language } = useLanguage();
@@ -81,53 +82,7 @@ export default function LandingContent() {
       </section>
 
       {/* Pricing Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold text-center mb-12">{t("pricing.title")}</h2>
-          <div className="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto">
-            {/* Free Plan */}
-            <div className="bg-white rounded-lg shadow-lg p-8">
-              <h3 className="text-2xl font-bold mb-4">{t("pricing.free.title")}</h3>
-              <p className="text-4xl font-bold mb-6">
-                $0<span className="text-lg text-gray-600">/month</span>
-              </p>
-              <ul className="space-y-4 mb-8">
-                {(t("pricing.free.features") as unknown as string[]).map((feature: string, index: number) => (
-                  <li key={index} className="flex items-center">
-                    <Check className="h-5 w-5 text-[#00B5B4] mr-2" />
-                    <span>{feature}</span>
-                  </li>
-                ))}
-              </ul>
-              <Link href="/sign-up">
-                <Button className="w-full" variant="outline">
-                  {t("pricing.free.cta")}
-                </Button>
-              </Link>
-            </div>
-
-            {/* Pro Plan */}
-            <div className="bg-white rounded-lg shadow-lg p-8 border-2 border-[#00B5B4] relative">
-              <div className="absolute top-0 right-0 bg-[#00B5B4] text-white px-3 py-1 text-sm rounded-bl-lg">
-                {t("pricing.pro.popular")}
-              </div>
-              <h3 className="text-2xl font-bold mb-4">{t("pricing.pro.title")}</h3>
-              <p className="text-4xl font-bold mb-6">
-                $9<span className="text-lg text-gray-600">/month</span>
-              </p>
-              <ul className="space-y-4 mb-8">
-                {(t("pricing.pro.features") as unknown as string[]).map((feature: string, index: number) => (
-                  <li key={index} className="flex items-center">
-                    <Check className="h-5 w-5 text-[#00B5B4] mr-2" />
-                    <span>{feature}</span>
-                  </li>
-                ))}
-              </ul>
-              <SubscribeButton />
-            </div>
-          </div>
-        </div>
-      </section>
+      <PricingSection />
 
       {/* CTA Section */}
       <section className="py-20 bg-white">

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -89,7 +89,7 @@ export default function PricingSection() {
                 $0<span className="text-lg text-gray-600">{t("pricing.perMonth")}</span>
               </p>
               <ul className="space-y-4 mb-8">
-                {(t("pricing.free.features") as string[]).map((feature, index) => (
+                {(t("pricing.free.features") as unknown as string[]).map((feature, index) => (
                   <li key={index} className="flex items-center">
                     <Check className="h-5 w-5 text-[#00B5B4] mr-2" />
                     <span>{feature}</span>
@@ -122,7 +122,7 @@ export default function PricingSection() {
                 <span className="text-lg text-gray-600">{t("pricing.perYear")}</span>
               </p>
               <ul className="space-y-4 mb-8">
-                {(t("pricing.pro.features") as string[]).map((feature, index) => (
+                {(t("pricing.pro.features") as unknown as string[]).map((feature, index) => (
                   <li key={index} className="flex items-center">
                     <Check className="h-5 w-5 text-[#00B5B4] mr-2" />
                     <span>{feature}</span>
@@ -146,7 +146,7 @@ export default function PricingSection() {
                 <span className="text-lg text-gray-600">{t("pricing.perMonth")}</span>
               </p>
               <ul className="space-y-4 mb-8">
-                {(t("pricing.pro.features") as string[]).map((feature, index) => (
+                {(t("pricing.pro.features") as unknown as string[]).map((feature, index) => (
                   <li key={index} className="flex items-center">
                     <Check className="h-5 w-5 text-[#00B5B4] mr-2" />
                     <span>{feature}</span>

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import Link from "next/link";
+import { Check, Package, Infinity } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/contexts/LanguageContext";
+import SubscribeButton from "@/components/SubscribeButton";
+import { useState } from "react";
+
+type ViewMode = 'subscriptions' | 'credits';
+
+interface CreditPackage {
+  credits: number;
+  price: number;
+  priceId: string;
+}
+
+export default function PricingSection() {
+  const { t } = useLanguage();
+  const [viewMode, setViewMode] = useState<ViewMode>('subscriptions');
+
+  const proPricing = {
+    monthly: {
+      price: 9,
+      priceId: 'price_1QSQRc04BafnFvRoRYz7KNbx'
+    },
+    annual: {
+      price: 90,
+      priceId: 'price_1QV5Ga04BafnFvRooTjkoZun'
+    }
+  };
+
+  const creditPackages: CreditPackage[] = [
+    {
+      credits: 10,
+      price: 10,
+      priceId: 'price_1QV5Mr04BafnFvRo949kW8y5'
+    },
+    {
+      credits: 30,
+      price: 25,
+      priceId: 'price_1QV5Pl04BafnFvRoKHf3V4mu'
+    },
+    {
+      credits: 75,
+      price: 50,
+      priceId: 'price_1QV5Qb04BafnFvRoiLl17ZP3'
+    }
+  ];
+
+  return (
+    <section className="py-20 bg-gray-50">
+      <div className="container mx-auto px-4">
+        <h2 className="text-3xl font-bold text-center mb-6">{t("pricing.title")}</h2>
+
+        {/* View Mode Toggle */}
+        <div className="flex justify-center gap-4 mb-8">
+          <button
+            onClick={() => setViewMode('subscriptions')}
+            className={`px-6 py-2 rounded-full transition-all ${
+              viewMode === 'subscriptions' 
+                ? 'bg-[#00B5B4] text-white' 
+                : 'bg-white text-gray-600 hover:bg-gray-100'
+            }`}
+          >
+            {t("pricing.subscriptions")}
+          </button>
+          <button
+            onClick={() => setViewMode('credits')}
+            className={`px-6 py-2 rounded-full transition-all ${
+              viewMode === 'credits' 
+                ? 'bg-[#00B5B4] text-white' 
+                : 'bg-white text-gray-600 hover:bg-gray-100'
+            }`}
+          >
+            {t("pricing.credits.title")}
+          </button>
+        </div>
+
+        {viewMode === 'subscriptions' && (
+          <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+            {/* Free Plan */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex justify-center mb-4">
+                <Package className="h-12 w-12 text-[#00B5B4]" />
+              </div>
+              <h3 className="text-2xl font-bold text-center mb-4">{t("pricing.free.title")}</h3>
+              <p className="text-4xl font-bold text-center mb-6">
+                $0<span className="text-lg text-gray-600">{t("pricing.perMonth")}</span>
+              </p>
+              <ul className="space-y-4 mb-8">
+                {(t("pricing.free.features") as string[]).map((feature, index) => (
+                  <li key={index} className="flex items-center">
+                    <Check className="h-5 w-5 text-[#00B5B4] mr-2" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              <Link href="/sign-up">
+                <Button className="w-full" variant="outline">
+                  {t("pricing.free.cta")}
+                </Button>
+              </Link>
+            </div>
+
+            {/* Annual Pro Plan */}
+            <div className="bg-white rounded-lg shadow-lg p-8 border-2 border-[#00B5B4] relative transform scale-105">
+              <div className="absolute top-0 right-0 bg-[#00B5B4] text-white px-3 py-1 text-sm rounded-bl-lg">
+                {t("pricing.pro.popular")}
+              </div>
+              <div className="flex justify-center mb-4">
+                <Infinity className="h-12 w-12 text-[#00B5B4]" />
+              </div>
+              <h3 className="text-2xl font-bold text-center mb-4">{t("pricing.pro.title")}</h3>
+              <div className="text-center mb-2">
+                <span className="text-sm bg-green-500 text-white px-2 py-1 rounded-full">
+                  {t("pricing.saveUpTo")} 17%
+                </span>
+              </div>
+              <p className="text-4xl font-bold text-center mb-6">
+                ${proPricing.annual.price}
+                <span className="text-lg text-gray-600">{t("pricing.perYear")}</span>
+              </p>
+              <ul className="space-y-4 mb-8">
+                {(t("pricing.pro.features") as string[]).map((feature, index) => (
+                  <li key={index} className="flex items-center">
+                    <Check className="h-5 w-5 text-[#00B5B4] mr-2" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              <SubscribeButton 
+                period="annual"
+                priceId={proPricing.annual.priceId}
+              />
+            </div>
+
+            {/* Monthly Pro Plan */}
+            <div className="bg-white rounded-lg shadow-lg p-8">
+              <div className="flex justify-center mb-4">
+                <Infinity className="h-12 w-12 text-[#00B5B4]" />
+              </div>
+              <h3 className="text-2xl font-bold text-center mb-4">{t("pricing.pro.title")}</h3>
+              <p className="text-4xl font-bold text-center mb-6">
+                ${proPricing.monthly.price}
+                <span className="text-lg text-gray-600">{t("pricing.perMonth")}</span>
+              </p>
+              <ul className="space-y-4 mb-8">
+                {(t("pricing.pro.features") as string[]).map((feature, index) => (
+                  <li key={index} className="flex items-center">
+                    <Check className="h-5 w-5 text-[#00B5B4] mr-2" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              <SubscribeButton 
+                period="monthly"
+                priceId={proPricing.monthly.priceId}
+              />
+            </div>
+          </div>
+        )}
+
+        {viewMode === 'credits' && (
+          <div className="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">
+            {creditPackages.map((pkg) => (
+              <div key={pkg.credits} className="bg-white rounded-lg shadow-lg p-8">
+                <div className="flex justify-center mb-4">
+                  <Package className="h-12 w-12 text-[#00B5B4]" />
+                </div>
+                <h3 className="text-2xl font-bold text-center mb-4">
+                  {pkg.credits} {t("pricing.credits.unit")}
+                </h3>
+                <p className="text-4xl font-bold text-center mb-6">
+                  ${pkg.price}
+                </p>
+                <p className="text-gray-600 text-center mb-8">
+                  ${(pkg.price / pkg.credits).toFixed(2)} {t("pricing.credits.perCredit")}
+                </p>
+                <SubscribeButton 
+                  priceId={pkg.priceId}
+                  isCredit
+                  credits={pkg.credits}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+} 

--- a/src/components/SubscriptionManagement.tsx
+++ b/src/components/SubscriptionManagement.tsx
@@ -3,7 +3,14 @@
 import { useEffect, useState } from "react";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { toast } from "sonner";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import SubscribeButton from "@/components/SubscribeButton";
 
 export default function SubscriptionManagement() {
@@ -72,11 +79,11 @@ export default function SubscriptionManagement() {
           <div>
             <p className="text-lg font-medium">
               {t("settings.subscription.status")}:{" "}
-              <span 
+              <span
                 className={
-                  subscription.status === "active" 
-                    ? "text-green-600" 
-                    : subscription.status === "free" 
+                  subscription.status === "active"
+                    ? "text-green-600"
+                    : subscription.status === "free"
                     ? "text-blue-600"
                     : "text-red-600"
                 }
@@ -99,7 +106,9 @@ export default function SubscriptionManagement() {
                   disabled={loading}
                   className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 disabled:opacity-50 transition-colors"
                 >
-                  {loading ? t("settings.subscription.reactivating") : t("settings.subscription.reactivate")}
+                  {loading
+                    ? t("settings.subscription.reactivating")
+                    : t("settings.subscription.reactivate")}
                 </button>
               ) : (
                 <button
@@ -110,11 +119,15 @@ export default function SubscriptionManagement() {
                 </button>
               )}
             </>
-          ) : subscription.status === "free" && (
-            <div className="flex items-center gap-2">
-              <p className="text-sm text-gray-500">{t("settings.subscription.upgradeCTA")}</p>
-              <SubscribeButton />
-            </div>
+          ) : (
+            subscription.status === "free" && (
+              <div className="flex items-center gap-2">
+                <p className="text-sm text-gray-500">
+                  {t("settings.subscription.upgradeCTA")}
+                </p>
+                <SubscribeButton priceId={subscription.priceId} />
+              </div>
+            )
           )}
         </div>
       </div>
@@ -122,7 +135,9 @@ export default function SubscriptionManagement() {
       <Dialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t("settings.subscription.cancelDialog.title")}</DialogTitle>
+            <DialogTitle>
+              {t("settings.subscription.cancelDialog.title")}
+            </DialogTitle>
             <DialogDescription>
               {t("settings.subscription.cancelDialog.description")}
             </DialogDescription>
@@ -140,7 +155,9 @@ export default function SubscriptionManagement() {
               disabled={loading}
               className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 disabled:opacity-50 transition-colors"
             >
-              {loading ? t("settings.subscription.canceling") : t("settings.subscription.cancelDialog.confirm")}
+              {loading
+                ? t("settings.subscription.canceling")
+                : t("settings.subscription.cancelDialog.confirm")}
             </button>
           </DialogFooter>
         </DialogContent>

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -43,6 +43,22 @@ export const translations = {
         popular: "Popular",
         loading: "Processing...",
       },
+      periods: {
+        monthly: "Monthly",
+        annual: "Annual",
+        lifetime: "Lifetime"
+      },
+      saveUpTo: "Save up to",
+      perMonth: "/mo",
+      perYear: "/yr",
+      subscriptions: "Subscriptions",
+      credits: {
+        title: "Credit Packages",
+        unit: "Credits",
+        perCredit: "per credit",
+        buy: "Buy Credits"
+      },
+      loading: "Processing..."
     },
     cta: {
       title: "Ready to Start Your House Sitting Journey?",
@@ -267,6 +283,22 @@ export const translations = {
         popular: "Popular",
         loading: "Processando...",
       },
+      periods: {
+        monthly: "Mensal",
+        annual: "Anual",
+        lifetime: "Vida"
+      },
+      saveUpTo: "Economize até",
+      perMonth: "/mês",
+      perYear: "/ano",
+      subscriptions: "Assinaturas",
+      credits: {
+        title: "Pacotes de Créditos",
+        unit: "Créditos",
+        perCredit: "por crédito",
+        buy: "Comprar Créditos"
+      },
+      loading: "Processando..."
     },
     cta: {
       title: "Pronto para Começar sua Jornada como House Sitter?",
@@ -494,6 +526,22 @@ export const translations = {
         popular: "Popular",
         loading: "Procesando...",
       },
+      periods: {
+        monthly: "Mensual",
+        annual: "Anual",
+        lifetime: "Vida"
+      },
+      saveUpTo: "Economize hasta",
+      perMonth: "/mes",
+      perYear: "/año",
+      subscriptions: "Suscripciones",
+      credits: {
+        title: "Paquetes de Créditos",
+        unit: "Créditos",
+        perCredit: "por crédito",
+        buy: "Comprar Créditos"
+      },
+      loading: "Procesando..."
     },
     cta: {
       title: "¿Listo para Comenzar tu Viaje como House Sitter?",


### PR DESCRIPTION
- Add separate tabs for subscriptions and credit packages
- Display subscription plans in 3-column layout (Free, Annual Pro, Monthly Pro)
- Highlight annual plan as recommended option with scale effect
- Remove monthly/annual toggle in favor of separate cards
- Add savings badge to annual plan
- Maintain consistent styling across all pricing options

BREAKING CHANGE: Pricing section layout has been completely restructured